### PR TITLE
Adds Docker development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .svn
 .DS_Store
+
+# WordPress Dev Environment
+src/wordpress

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ To embed a note, use any note-specific URL. Notes ignore `width/height` and alwa
 
 Here's the full list of embed options you can pass via shortcode attributes; some are specific to the type of resource you're embedding.
 
+
 ### All resources:
 
 - `url` (**required**, string): Full URL of the DocumentCloud resource.
@@ -84,6 +85,32 @@ If you find yourself absolutely needing to expire the cache, though, you have tw
 
 1. Delete the appropriate `_oembed_*` rows from your `postmeta` table.
 2. Modify the shortcode attributes for the embed, since this is recognized as a new embed by WordPress.
+
+## Development
+
+Docker is used to host development environments for Wordpress and React.
+
+### Install
+
+#### React Dev Environment
+
+```sh
+cd src/react-embed
+npm install
+npm run dev
+```
+
+#### Wordpress Dev Environment
+
+```sh
+# Start services
+docker compose up
+# Fix permissions
+docker-compose exec wordpress chown -R www-data:www-data /var/www/html
+```
+
+1. Go to `localhost:8000`
+2. Create an account. Save the username and password, then log in.
 
 ## Changelog
 
@@ -143,3 +170,4 @@ If you find yourself absolutely needing to expire the cache, though, you have tw
 ## License and History
 
 The DocumentCloud WordPress plugin is [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html). Initial development of this plugin by Chris Amico (@eyeseast) supported by [NPR](http://www.npr.org) as part of the [StateImpact](http://stateimpact.npr.org) project. Development continued by Justin Reese (@reefdog) at [DocumentCloud](https://www.documentcloud.org/).
+

--- a/README.md
+++ b/README.md
@@ -88,19 +88,9 @@ If you find yourself absolutely needing to expire the cache, though, you have tw
 
 ## Development
 
-Docker is used to host development environments for Wordpress and React.
+Docker is used to spin up a development and testing WordPress environment.
 
 ### Install
-
-#### React Dev Environment
-
-```sh
-cd src/react-embed
-npm install
-npm run dev
-```
-
-#### Wordpress Dev Environment
 
 ```sh
 # Start services
@@ -111,6 +101,7 @@ docker-compose exec wordpress chown -R www-data:www-data /var/www/html
 
 1. Go to `localhost:8000`
 2. Create an account. Save the username and password, then log in.
+3. Go to the Plugins section, then activate the "Classic Editor" and "DocumentCloud" plugins.
 
 ## Changelog
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       WORDPRESS_TABLE_PREFIX: wp_
     volumes:
       - ./src/wordpress:/var/www/html
+      - ./documentcloud.php:/var/www/html/wp-content/plugins/documentcloud/documentcloud.php
     depends_on:
       - db
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  wordpress:
+    restart: always
+    image: wordpress:latest
+    container_name: wordpress
+    ports:
+      - "8000:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: root
+      WORDPRESS_DB_PASSWORD: password
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_TABLE_PREFIX: wp_
+    volumes:
+      - ./src/wordpress:/var/www/html
+    depends_on:
+      - db
+    networks:
+      - wp_net
+  
+  phpmyadmin:
+    depends_on:
+      - db
+    image: phpmyadmin/phpmyadmin:latest
+    container_name: phpmyadmin
+    restart: always
+    platform: linux/amd64
+    ports:
+      - 8180:80
+    environment:
+      PMA_HOST: db
+      MYSQL_ROOT_PASSWORD: password
+    networks:
+      - wp_net
+
+  db:
+    image: mariadb:latest
+    container_name: db
+    volumes:
+      - db_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_DATABASE=wordpress
+    restart: always
+    networks:
+      - wp_net
+
+volumes:
+  db_data:
+
+networks:
+  wp_net:
+    driver: bridge


### PR DESCRIPTION
This adds a Docker compose file to spin up a local WordPress dev server. When building, the plugin file is copied into the dev server's plugin directory.

This should make it easier for us to ensure the plugin works in the latest version of WordPress.

To test, follow "Development / Install" steps in README.md