### PR TITLE
Packaging script fix

### DIFF
--- a/package-plugin.sh
+++ b/package-plugin.sh
@@ -46,7 +46,7 @@ rsync -av \
     --exclude='.*' \
     --exclude='*/.*' \
     --exclude='node_modules/' \
-    --exclude='blocks/' \
+    --exclude='/blocks/' \
     "$SOURCE_DIR/" "$DIST_DIR/$PLUGIN_NAME/"
 
 # Step 2.1: Clean up any remaining hidden files that might have been copied


### PR DESCRIPTION
The packaging script accidentally omitted all `blocks` directories during step 2. This updates it to only omit the `src/documentcloud/blocks` directory, but copy over other directories named `blocks`.