### PR TITLE
Fix MySQL test certificates

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           MYSQL_DATABASE: wordpress_test
           MYSQL_ROOT_PASSWORD: root
-        options: --ssl-mode=DISABLED --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install WP test suite
         run: |
-          mysql -u root -proot -h mysql -P 3306 -e "DROP DATABASE IF EXISTS wordpress_test;"
+          mysql --ssl-mode=DISABLED -u root -proot -h mysql -P 3306 -e "DROP DATABASE IF EXISTS wordpress_test;"
           bash ./bin/install-wp-tests.sh wordpress_test root 'root' mysql ${{ matrix.wp-version }}
 
       - name: Run PHPUnit with coverage

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           MYSQL_DATABASE: wordpress_test
           MYSQL_ROOT_PASSWORD: root
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --ssl-mode=DISABLED --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 
 
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install WP test suite
         run: |
-          mysql -u root -proot -h mysql -P 3306 -e "DROP DATABASE IF EXISTS wordpress_test;"
+          mysql --ssl-mode=DISABLED -u root -proot -h mysql -P 3306 -e "DROP DATABASE IF EXISTS wordpress_test;"
           bash ./bin/install-wp-tests.sh wordpress_test root 'root' mysql ${{ matrix.wp-version }}
 
       - name: Run PHPUnit with coverage

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install WP test suite
         run: |
-          mysql --ssl-mode=DISABLED -u root -proot -h mysql -P 3306 -e "DROP DATABASE IF EXISTS wordpress_test;"
+          mysql -u root -proot -h mysql -P 3306 -e "DROP DATABASE IF EXISTS wordpress_test;"
           bash ./bin/install-wp-tests.sh wordpress_test root 'root' mysql ${{ matrix.wp-version }}
 
       - name: Run PHPUnit with coverage

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install WP test suite
         run: |
-          mysql --ssl-mode=DISABLED -u root -proot -h mysql -P 3306 -e "DROP DATABASE IF EXISTS wordpress_test;"
+          mysql --skip-ssl -u root -proot -h mysql -P 3306 -e "DROP DATABASE IF EXISTS wordpress_test;"
           bash ./bin/install-wp-tests.sh wordpress_test root 'root' mysql ${{ matrix.wp-version }}
 
       - name: Run PHPUnit with coverage

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -130,7 +130,7 @@ recreate_db() {
 	shopt -s nocasematch
 	if [[ $1 =~ ^(y|yes)$ ]]
 	then
-		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		mysqladmin drop $DB_NAME -f --skip-ssl --user="$DB_USER" --password="$DB_PASS"$EXTRA
 		create_db
 		echo "Recreated the database ($DB_NAME)."
 	else
@@ -140,7 +140,7 @@ recreate_db() {
 }
 
 create_db() {
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	mysqladmin create $DB_NAME --skip-ssl --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 
 install_db() {

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -166,7 +166,7 @@ install_db() {
 	fi
 
 	# create database
-	if [ $(mysql --ssl-mode=DISABLED --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
+	if [ $(mysql --skip-ssl --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
 		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -166,7 +166,7 @@ install_db() {
 	fi
 
 	# create database
-	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
+	if [ $(mysql --ssl-mode=DISABLED --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
 		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB


### PR DESCRIPTION
We've had some certificate errors when testing. Since this is a temporary database that's thrown out after tests are over and contain no significant data, it's safe to use an unencrypted connection. This applies the `--skip-ssl` flag to our database commands.